### PR TITLE
Filter by Credibility Score Implementation UC7 

### DIFF
--- a/src/main/java/app/AppBuilder.java
+++ b/src/main/java/app/AppBuilder.java
@@ -15,6 +15,9 @@ import interface_adapter.discover_page.*;
 import interface_adapter.generate_credibility.GenerateCredibilityController;
 import interface_adapter.generate_credibility.GenerateCredibilityPresenter;
 import interface_adapter.generate_credibility.DiscoverGenerateCredibilityPresenter;
+import interface_adapter.filter_credibility.FilterCredibilityController;
+import interface_adapter.filter_credibility.TopHeadlinesFilterCredibilityPresenter;
+import interface_adapter.filter_credibility.DiscoverPageFilterCredibilityPresenter;
 import interface_adapter.view_credibility.ViewCredibilityDetailsViewModel;
 import interface_adapter.view_credibility.ViewCredibilityDetailsPresenter;
 import interface_adapter.view_credibility.ViewCredibilityDetailsController;
@@ -38,6 +41,9 @@ import use_case.generate_credibility.GenerateCredibilityOutputBoundary;
 import use_case.view_credibility.ViewCredibilityDetailsInputBoundary;
 import use_case.view_credibility.ViewCredibilityDetailsInteractor;
 import use_case.view_credibility.ViewCredibilityDetailsOutputBoundary;
+import use_case.filter_credibility.FilterCredibilityInputBoundary;
+import use_case.filter_credibility.FilterCredibilityInteractor;
+import use_case.filter_credibility.FilterCredibilityOutputBoundary;
 import use_case.load_saved_articles.*;
 import use_case.save_article.SaveArticleDataAccessInterface;
 import view.LoginView;
@@ -288,6 +294,35 @@ public class AppBuilder {
                 credibilityDetailsController,
                 viewCredibilityDetailsViewModel
         );
+
+        return this;
+    }
+
+    public AppBuilder addFilterCredibilityUseCase() {
+        // Create presenter for Top Headlines view
+        FilterCredibilityOutputBoundary filterPresenterTop =
+                new TopHeadlinesFilterCredibilityPresenter(topHeadlinesViewModel);
+        FilterCredibilityInputBoundary filterInteractorTop =
+                new FilterCredibilityInteractor(filterPresenterTop);
+        FilterCredibilityController filterControllerTop =
+                new FilterCredibilityController(filterInteractorTop);
+
+        // Create presenter for Discover Page view
+        FilterCredibilityOutputBoundary filterPresenterDiscover =
+                new DiscoverPageFilterCredibilityPresenter(discoverPageViewModel);
+        FilterCredibilityInputBoundary filterInteractorDiscover =
+                new FilterCredibilityInteractor(filterPresenterDiscover);
+        FilterCredibilityController filterControllerDiscover =
+                new FilterCredibilityController(filterInteractorDiscover);
+
+        // Pass controllers to views
+        if (topHeadlinesView != null) {
+            topHeadlinesView.setFilterCredibilityController(filterControllerTop);
+        }
+
+        if (discoverPageView != null) {
+            discoverPageView.setFilterCredibilityController(filterControllerDiscover);
+        }
 
         return this;
     }

--- a/src/main/java/app/AppBuilder.java
+++ b/src/main/java/app/AppBuilder.java
@@ -62,7 +62,7 @@ public class AppBuilder {
     private final ViewManagerModel viewManagerModel = new ViewManagerModel();
     private final ViewManager viewManager =
             new ViewManager(cardPanel, cardLayout, viewManagerModel);
-    private final DBUserDataAccessObject newsDataAccessObject = new DBUserDataAccessObject();
+    private DBUserDataAccessObject newsDataAccessObject;
     private FileUserDataAccessObject userDataAccessObject;
 
     private LoginView loginView;
@@ -111,6 +111,9 @@ public class AppBuilder {
     }
 
     public AppBuilder addTopHeadlinesUseCase() {
+        if (newsDataAccessObject == null) {
+            newsDataAccessObject = new DBUserDataAccessObject();
+        }
         TopHeadlinesUserDataAccessInterface dao = newsDataAccessObject;
         TopHeadlinesPresenter presenter = new TopHeadlinesPresenter(topHeadlinesViewModel);
         TopHeadlinesInputBoundary interactor = new TopHeadlinesInteractor(dao, presenter);
@@ -137,6 +140,9 @@ public class AppBuilder {
     }
 
     public AppBuilder addSearchNewsUseCase() {
+        if (newsDataAccessObject == null) {
+            newsDataAccessObject = new DBUserDataAccessObject();
+        }
         SearchNewsOutputBoundary presenter = new SearchNewsPresenter(topHeadlinesViewModel);
         SearchNewsInputBoundary interactor =
                 new SearchNewsInteractor(newsDataAccessObject, presenter);
@@ -170,11 +176,19 @@ public class AppBuilder {
     }
 
     public AppBuilder addDiscoverPageUseCase() {
+        // Ensure newsDataAccessObject has FileUserDataAccessObject for Discover Page
+        if (newsDataAccessObject == null) {
+            newsDataAccessObject = new DBUserDataAccessObject(getUserDataAccessObject());
+        } else {
+            // If it was created without userDataAccess, recreate it with userDataAccess
+            // This is safe because DBUserDataAccessObject is stateless except for userDataAccess
+            newsDataAccessObject = new DBUserDataAccessObject(getUserDataAccessObject());
+        }
         DiscoverPageOutputBoundary presenter = new DiscoverPagePresenter(discoverPageViewModel);
         DiscoverPageInputBoundary interactor =
                 new DiscoverPageInteractor(newsDataAccessObject, presenter);
         DiscoverPageController controller =
-                new DiscoverPageController(interactor, discoverPageViewModel);
+                new DiscoverPageController(interactor, discoverPageViewModel, loginViewModel);
         discoverPageView.setController(controller);
         return this;
     }

--- a/src/main/java/app/Main.java
+++ b/src/main/java/app/Main.java
@@ -17,6 +17,7 @@ public class Main {
                 .addSearchNewsUseCase()
                 .addDiscoverPageView()
                 .addCredibilityUseCases()
+                .addFilterCredibilityUseCase()
                 .addDiscoverPageUseCase()
                 .addProfileView()
                 .addProfileUseCase()

--- a/src/main/java/data_access/DBUserDataAccessObject.java
+++ b/src/main/java/data_access/DBUserDataAccessObject.java
@@ -11,7 +11,6 @@ import use_case.top_headlines.TopHeadlinesUserDataAccessInterface;
 import use_case.discover_page.DiscoverPageDataAccessInterface;
 import util.EnvLoader;
 
-import java.io.*;
 import java.util.*;
 
 public class DBUserDataAccessObject implements
@@ -20,6 +19,15 @@ public class DBUserDataAccessObject implements
         DiscoverPageDataAccessInterface {
 
     private static final String API_KEY = getEnvOrThrow("NEWSDATA_API_KEY", "NewsData API key");
+    private final FileUserDataAccessObject userDataAccess;
+
+    public DBUserDataAccessObject() {
+        this.userDataAccess = null;
+    }
+
+    public DBUserDataAccessObject(FileUserDataAccessObject userDataAccess) {
+        this.userDataAccess = userDataAccess;
+    }
 
     private static String getEnvOrThrow(String envName, String label) {
         String value = EnvLoader.get(envName);  // <-- Use loader instead
@@ -141,41 +149,25 @@ public class DBUserDataAccessObject implements
     }
 
     @Override
-    public List<Article> getReadingHistory() {
+    public List<Article> getReadingHistory(String username) {
         List<Article> savedArticles = new ArrayList<>();
-        // Use the same path as FileSaveArticleDataAccess for consistency
-        // Create file using the same relative path resolution
-        File savedFile = new File("data/saved_articles.txt");
         
-        // Get absolute path to ensure we're reading from the correct location
-        String absolutePath = savedFile.getAbsolutePath();
-        savedFile = new File(absolutePath);
-
-        if (!savedFile.exists()) {
+        if (userDataAccess == null) {
+            System.err.println("Error: FileUserDataAccessObject not initialized");
             return savedArticles;
         }
 
+        if (username == null || username.isBlank()) {
+            return savedArticles;
+        }
 
-        try (FileReader fr = new FileReader(savedFile);
-             BufferedReader br = new BufferedReader(fr)) {
-            String line;
-            while ((line = br.readLine()) != null) {
-                if (line.isBlank()) continue;
-
-                String[] parts = line.split("\\|", 3);
-                if (parts.length >= 3) {
-                    String id = parts[0].trim();
-                    String title = parts[1].trim();
-                    String url = parts[2].trim();
-
-                    if (!title.isEmpty() && !url.isEmpty()) {
-                        Article article = new Article(id, title, "", url, "", "Unknown");
-                        savedArticles.add(article);
-                    }
-                }
+        try {
+            entity.User user = userDataAccess.get(username);
+            if (user != null) {
+                savedArticles = new ArrayList<>(user.getSavedArticles());
             }
-        } catch (IOException e) {
-            System.err.println("Error reading saved articles: " + e.getMessage());
+        } catch (Exception e) {
+            System.err.println("Error reading saved articles for user " + username + ": " + e.getMessage());
         }
 
         return savedArticles;

--- a/src/main/java/interface_adapter/discover_page/DiscoverPageController.java
+++ b/src/main/java/interface_adapter/discover_page/DiscoverPageController.java
@@ -1,5 +1,6 @@
 package interface_adapter.discover_page;
 
+import interface_adapter.login.LoginViewModel;
 import use_case.discover_page.DiscoverPageInputBoundary;
 import use_case.discover_page.DiscoverPageInputData;
 
@@ -8,18 +9,22 @@ import java.util.Set;
 public class DiscoverPageController {
     private final DiscoverPageInputBoundary discoverPageUseCaseInteractor;
     private final DiscoverPageViewModel discoverPageViewModel;
+    private final LoginViewModel loginViewModel;
 
     public DiscoverPageController(DiscoverPageInputBoundary discoverPageUseCaseInteractor,
-                                  DiscoverPageViewModel discoverPageViewModel) {
+                                  DiscoverPageViewModel discoverPageViewModel,
+                                  LoginViewModel loginViewModel) {
         this.discoverPageUseCaseInteractor = discoverPageUseCaseInteractor;
         this.discoverPageViewModel = discoverPageViewModel;
+        this.loginViewModel = loginViewModel;
     }
 
     public void execute() {
         DiscoverPageState state = discoverPageViewModel.getState();
         Set<String> currentTopics = state.getCurrentTopics();
         int currentPage = state.getCurrentPage();
-        DiscoverPageInputData inputData = new DiscoverPageInputData(currentTopics, currentPage);
+        String username = loginViewModel.getState().getUsername();
+        DiscoverPageInputData inputData = new DiscoverPageInputData(currentTopics, currentPage, username);
         discoverPageUseCaseInteractor.execute(inputData);
     }
 }

--- a/src/main/java/interface_adapter/discover_page/DiscoverPageState.java
+++ b/src/main/java/interface_adapter/discover_page/DiscoverPageState.java
@@ -12,6 +12,8 @@ public class DiscoverPageState {
     private boolean hasNoArticles;
     private Set<String> currentTopics = new java.util.HashSet<>();
     private int currentPage = 0;
+    private List<Article> originalArticles = new ArrayList<>(); // Stores unfiltered articles
+    private String currentFilterLevel; // "High", "Medium", "Low", "All", or null
 
     public List<Article> getArticles() {
         return articles;
@@ -59,6 +61,46 @@ public class DiscoverPageState {
 
     public void setCurrentPage(int currentPage) {
         this.currentPage = currentPage;
+    }
+
+    /**
+     * Gets the original unfiltered articles list.
+     * @return the original articles list
+     */
+    public List<Article> getOriginalArticles() {
+        return originalArticles;
+    }
+
+    /**
+     * Sets the original unfiltered articles list.
+     * @param originalArticles the original articles list to store
+     */
+    public void setOriginalArticles(List<Article> originalArticles) {
+        this.originalArticles = originalArticles != null ? new ArrayList<>(originalArticles) : new ArrayList<>();
+    }
+
+    /**
+     * Gets the current filter level.
+     * @return the current filter level ("High", "Medium", "Low", "All", or null)
+     */
+    public String getCurrentFilterLevel() {
+        return currentFilterLevel;
+    }
+
+    /**
+     * Sets the current filter level.
+     * @param currentFilterLevel the filter level to set ("High", "Medium", "Low", "All", or null)
+     */
+    public void setCurrentFilterLevel(String currentFilterLevel) {
+        this.currentFilterLevel = currentFilterLevel;
+    }
+
+    /**
+     * Checks if articles are currently filtered.
+     * @return true if filtering is active (filter level is not null and not "All"), false otherwise
+     */
+    public boolean isFiltered() {
+        return currentFilterLevel != null && !"All".equalsIgnoreCase(currentFilterLevel);
     }
 }
 

--- a/src/main/java/interface_adapter/discover_page/DiscoverPageState.java
+++ b/src/main/java/interface_adapter/discover_page/DiscoverPageState.java
@@ -13,7 +13,7 @@ public class DiscoverPageState {
     private Set<String> currentTopics = new java.util.HashSet<>();
     private int currentPage = 0;
     private List<Article> originalArticles = new ArrayList<>(); // Stores unfiltered articles
-    private String currentFilterLevel; // "High", "Medium", "Low", "All", or null
+    private java.util.Set<String> currentFilterLevels = new java.util.HashSet<>(); // Set of "High", "Medium", "Low" - empty means no filter
 
     public List<Article> getArticles() {
         return articles;
@@ -80,27 +80,27 @@ public class DiscoverPageState {
     }
 
     /**
-     * Gets the current filter level.
-     * @return the current filter level ("High", "Medium", "Low", "All", or null)
+     * Gets the current filter levels.
+     * @return the set of current filter levels ("High", "Medium", "Low") - empty set means no filter
      */
-    public String getCurrentFilterLevel() {
-        return currentFilterLevel;
+    public java.util.Set<String> getCurrentFilterLevels() {
+        return currentFilterLevels;
     }
 
     /**
-     * Sets the current filter level.
-     * @param currentFilterLevel the filter level to set ("High", "Medium", "Low", "All", or null)
+     * Sets the current filter levels.
+     * @param currentFilterLevels the set of filter levels to set ("High", "Medium", "Low") - empty set means no filter
      */
-    public void setCurrentFilterLevel(String currentFilterLevel) {
-        this.currentFilterLevel = currentFilterLevel;
+    public void setCurrentFilterLevels(java.util.Set<String> currentFilterLevels) {
+        this.currentFilterLevels = currentFilterLevels != null ? new java.util.HashSet<>(currentFilterLevels) : new java.util.HashSet<>();
     }
 
     /**
      * Checks if articles are currently filtered.
-     * @return true if filtering is active (filter level is not null and not "All"), false otherwise
+     * @return true if filtering is active (filter levels set is not empty), false otherwise
      */
     public boolean isFiltered() {
-        return currentFilterLevel != null && !"All".equalsIgnoreCase(currentFilterLevel);
+        return currentFilterLevels != null && !currentFilterLevels.isEmpty();
     }
 }
 

--- a/src/main/java/interface_adapter/filter_credibility/DiscoverPageFilterCredibilityPresenter.java
+++ b/src/main/java/interface_adapter/filter_credibility/DiscoverPageFilterCredibilityPresenter.java
@@ -19,7 +19,7 @@ public class DiscoverPageFilterCredibilityPresenter implements FilterCredibility
     public void presentSuccess(FilterCredibilityOutputData outputData) {
         var state = viewModel.getState();
         state.setArticles(outputData.getFilteredArticles());
-        state.setCurrentFilterLevel(outputData.getFilterLevel());
+        state.setCurrentFilterLevels(outputData.getFilterLevels());
         state.setMessage(null); // Clear any previous messages
         state.setHasNoArticles(false);
         state.setHasNoHistory(false);
@@ -30,7 +30,8 @@ public class DiscoverPageFilterCredibilityPresenter implements FilterCredibility
     public void presentError(String errorMessage) {
         var state = viewModel.getState();
         state.setMessage(errorMessage);
-        state.setHasNoArticles(true); // Show message view
+        // Don't set hasNoArticles = true, keep articles visible and show error in popup
+        state.setHasNoArticles(false);
         state.setHasNoHistory(false);
         viewModel.firePropertyChange();
     }

--- a/src/main/java/interface_adapter/filter_credibility/DiscoverPageFilterCredibilityPresenter.java
+++ b/src/main/java/interface_adapter/filter_credibility/DiscoverPageFilterCredibilityPresenter.java
@@ -1,4 +1,36 @@
 package interface_adapter.filter_credibility;
 
-public class DiscoverPageFilterCredibilityPresenter {
+import interface_adapter.discover_page.DiscoverPageViewModel;
+import use_case.filter_credibility.FilterCredibilityOutputBoundary;
+import use_case.filter_credibility.FilterCredibilityOutputData;
+
+/**
+ * Presenter for filtering credibility scores in the Discover Page view.
+ * Updates the DiscoverPageViewModel with filtered articles or error messages.
+ */
+public class DiscoverPageFilterCredibilityPresenter implements FilterCredibilityOutputBoundary {
+    private final DiscoverPageViewModel viewModel;
+
+    public DiscoverPageFilterCredibilityPresenter(DiscoverPageViewModel viewModel) {
+        this.viewModel = viewModel;
+    }
+
+    @Override
+    public void presentSuccess(FilterCredibilityOutputData outputData) {
+        var state = viewModel.getState();
+        state.setArticles(outputData.getFilteredArticles());
+        state.setMessage(null); // Clear any previous messages
+        state.setHasNoArticles(false);
+        state.setHasNoHistory(false);
+        viewModel.firePropertyChange();
+    }
+
+    @Override
+    public void presentError(String errorMessage) {
+        var state = viewModel.getState();
+        state.setMessage(errorMessage);
+        state.setHasNoArticles(true); // Show message view
+        state.setHasNoHistory(false);
+        viewModel.firePropertyChange();
+    }
 }

--- a/src/main/java/interface_adapter/filter_credibility/DiscoverPageFilterCredibilityPresenter.java
+++ b/src/main/java/interface_adapter/filter_credibility/DiscoverPageFilterCredibilityPresenter.java
@@ -19,6 +19,7 @@ public class DiscoverPageFilterCredibilityPresenter implements FilterCredibility
     public void presentSuccess(FilterCredibilityOutputData outputData) {
         var state = viewModel.getState();
         state.setArticles(outputData.getFilteredArticles());
+        state.setCurrentFilterLevel(outputData.getFilterLevel());
         state.setMessage(null); // Clear any previous messages
         state.setHasNoArticles(false);
         state.setHasNoHistory(false);

--- a/src/main/java/interface_adapter/filter_credibility/DiscoverPageFilterCredibilityPresenter.java
+++ b/src/main/java/interface_adapter/filter_credibility/DiscoverPageFilterCredibilityPresenter.java
@@ -1,0 +1,4 @@
+package interface_adapter.filter_credibility;
+
+public class DiscoverPageFilterCredibilityPresenter {
+}

--- a/src/main/java/interface_adapter/filter_credibility/FilterCredibilityController.java
+++ b/src/main/java/interface_adapter/filter_credibility/FilterCredibilityController.java
@@ -1,0 +1,4 @@
+package interface_adapter.filter_credibility;
+
+public class FilterCredibilityController {
+}

--- a/src/main/java/interface_adapter/filter_credibility/FilterCredibilityController.java
+++ b/src/main/java/interface_adapter/filter_credibility/FilterCredibilityController.java
@@ -1,4 +1,30 @@
 package interface_adapter.filter_credibility;
 
+import entity.Article;
+import use_case.filter_credibility.FilterCredibilityInputBoundary;
+import use_case.filter_credibility.FilterCredibilityInputData;
+
+import java.util.List;
+
+/**
+ * Controller for the filter credibility use case.
+ * Handles requests from views to filter articles by trust score level.
+ */
 public class FilterCredibilityController {
+    private final FilterCredibilityInputBoundary interactor;
+
+    public FilterCredibilityController(FilterCredibilityInputBoundary interactor) {
+        this.interactor = interactor;
+    }
+
+    /**
+     * Filters articles by the specified trust score level.
+     * 
+     * @param articles the list of articles to filter
+     * @param filterLevel the trust level to filter by ("High", "Medium", "Low", or "All"/null for all articles)
+     */
+    public void filterArticles(List<Article> articles, String filterLevel) {
+        FilterCredibilityInputData inputData = new FilterCredibilityInputData(articles, filterLevel);
+        interactor.execute(inputData);
+    }
 }

--- a/src/main/java/interface_adapter/filter_credibility/FilterCredibilityController.java
+++ b/src/main/java/interface_adapter/filter_credibility/FilterCredibilityController.java
@@ -5,6 +5,7 @@ import use_case.filter_credibility.FilterCredibilityInputBoundary;
 import use_case.filter_credibility.FilterCredibilityInputData;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * Controller for the filter credibility use case.
@@ -18,13 +19,14 @@ public class FilterCredibilityController {
     }
 
     /**
-     * Filters articles by the specified trust score level.
+     * Filters articles by the specified trust score levels.
      * 
      * @param articles the list of articles to filter
-     * @param filterLevel the trust level to filter by ("High", "Medium", "Low", or "All"/null for all articles)
+     * @param filterLevels the set of trust levels to filter by ("High", "Medium", "Low")
+     *                      Empty set means show all articles
      */
-    public void filterArticles(List<Article> articles, String filterLevel) {
-        FilterCredibilityInputData inputData = new FilterCredibilityInputData(articles, filterLevel);
+    public void filterArticles(List<Article> articles, Set<String> filterLevels) {
+        FilterCredibilityInputData inputData = new FilterCredibilityInputData(articles, filterLevels);
         interactor.execute(inputData);
     }
 }

--- a/src/main/java/interface_adapter/filter_credibility/TopHeadlinesFilterCredibilityPresenter.java
+++ b/src/main/java/interface_adapter/filter_credibility/TopHeadlinesFilterCredibilityPresenter.java
@@ -19,7 +19,7 @@ public class TopHeadlinesFilterCredibilityPresenter implements FilterCredibility
     public void presentSuccess(FilterCredibilityOutputData outputData) {
         var state = viewModel.getState();
         state.setArticles(outputData.getFilteredArticles());
-        state.setCurrentFilterLevel(outputData.getFilterLevel());
+        state.setCurrentFilterLevels(outputData.getFilterLevels());
         state.setError(null); // Clear any previous errors
         viewModel.firePropertyChange();
     }

--- a/src/main/java/interface_adapter/filter_credibility/TopHeadlinesFilterCredibilityPresenter.java
+++ b/src/main/java/interface_adapter/filter_credibility/TopHeadlinesFilterCredibilityPresenter.java
@@ -19,6 +19,7 @@ public class TopHeadlinesFilterCredibilityPresenter implements FilterCredibility
     public void presentSuccess(FilterCredibilityOutputData outputData) {
         var state = viewModel.getState();
         state.setArticles(outputData.getFilteredArticles());
+        state.setCurrentFilterLevel(outputData.getFilterLevel());
         state.setError(null); // Clear any previous errors
         viewModel.firePropertyChange();
     }

--- a/src/main/java/interface_adapter/filter_credibility/TopHeadlinesFilterCredibilityPresenter.java
+++ b/src/main/java/interface_adapter/filter_credibility/TopHeadlinesFilterCredibilityPresenter.java
@@ -1,4 +1,32 @@
 package interface_adapter.filter_credibility;
 
-public class TopHeadlinesFilterCredibilityPresenter {
+import interface_adapter.top_headlines.TopHeadlinesViewModel;
+import use_case.filter_credibility.FilterCredibilityOutputBoundary;
+import use_case.filter_credibility.FilterCredibilityOutputData;
+
+/**
+ * Presenter for filtering credibility scores in the Top Headlines view.
+ * Updates the TopHeadlinesViewModel with filtered articles or error messages.
+ */
+public class TopHeadlinesFilterCredibilityPresenter implements FilterCredibilityOutputBoundary {
+    private final TopHeadlinesViewModel viewModel;
+
+    public TopHeadlinesFilterCredibilityPresenter(TopHeadlinesViewModel viewModel) {
+        this.viewModel = viewModel;
+    }
+
+    @Override
+    public void presentSuccess(FilterCredibilityOutputData outputData) {
+        var state = viewModel.getState();
+        state.setArticles(outputData.getFilteredArticles());
+        state.setError(null); // Clear any previous errors
+        viewModel.firePropertyChange();
+    }
+
+    @Override
+    public void presentError(String errorMessage) {
+        var state = viewModel.getState();
+        state.setError(errorMessage);
+        viewModel.firePropertyChange();
+    }
 }

--- a/src/main/java/interface_adapter/filter_credibility/TopHeadlinesFilterCredibilityPresenter.java
+++ b/src/main/java/interface_adapter/filter_credibility/TopHeadlinesFilterCredibilityPresenter.java
@@ -1,0 +1,4 @@
+package interface_adapter.filter_credibility;
+
+public class TopHeadlinesFilterCredibilityPresenter {
+}

--- a/src/main/java/interface_adapter/top_headlines/TopHeadlinesState.java
+++ b/src/main/java/interface_adapter/top_headlines/TopHeadlinesState.java
@@ -7,6 +7,8 @@ import java.util.List;
 public class TopHeadlinesState {
     private List<Article> articles = new ArrayList<>();
     private String error;
+    private List<Article> originalArticles = new ArrayList<>(); // Stores unfiltered articles
+    private String currentFilterLevel; // "High", "Medium", "Low", "All", or null
 
     public List<Article> getArticles() {
         return articles;
@@ -30,5 +32,45 @@ public class TopHeadlinesState {
      */
     public void setError(String error) {
         this.error = error;
+    }
+
+    /**
+     * Gets the original unfiltered articles list.
+     * @return the original articles list
+     */
+    public List<Article> getOriginalArticles() {
+        return originalArticles;
+    }
+
+    /**
+     * Sets the original unfiltered articles list.
+     * @param originalArticles the original articles list to store
+     */
+    public void setOriginalArticles(List<Article> originalArticles) {
+        this.originalArticles = originalArticles != null ? new ArrayList<>(originalArticles) : new ArrayList<>();
+    }
+
+    /**
+     * Gets the current filter level.
+     * @return the current filter level ("High", "Medium", "Low", "All", or null)
+     */
+    public String getCurrentFilterLevel() {
+        return currentFilterLevel;
+    }
+
+    /**
+     * Sets the current filter level.
+     * @param currentFilterLevel the filter level to set ("High", "Medium", "Low", "All", or null)
+     */
+    public void setCurrentFilterLevel(String currentFilterLevel) {
+        this.currentFilterLevel = currentFilterLevel;
+    }
+
+    /**
+     * Checks if articles are currently filtered.
+     * @return true if filtering is active (filter level is not null and not "All"), false otherwise
+     */
+    public boolean isFiltered() {
+        return currentFilterLevel != null && !"All".equalsIgnoreCase(currentFilterLevel);
     }
 }

--- a/src/main/java/interface_adapter/top_headlines/TopHeadlinesState.java
+++ b/src/main/java/interface_adapter/top_headlines/TopHeadlinesState.java
@@ -8,7 +8,7 @@ public class TopHeadlinesState {
     private List<Article> articles = new ArrayList<>();
     private String error;
     private List<Article> originalArticles = new ArrayList<>(); // Stores unfiltered articles
-    private String currentFilterLevel; // "High", "Medium", "Low", "All", or null
+    private java.util.Set<String> currentFilterLevels = new java.util.HashSet<>(); // Set of "High", "Medium", "Low" - empty means no filter
 
     public List<Article> getArticles() {
         return articles;
@@ -51,26 +51,26 @@ public class TopHeadlinesState {
     }
 
     /**
-     * Gets the current filter level.
-     * @return the current filter level ("High", "Medium", "Low", "All", or null)
+     * Gets the current filter levels.
+     * @return the set of current filter levels ("High", "Medium", "Low") - empty set means no filter
      */
-    public String getCurrentFilterLevel() {
-        return currentFilterLevel;
+    public java.util.Set<String> getCurrentFilterLevels() {
+        return currentFilterLevels;
     }
 
     /**
-     * Sets the current filter level.
-     * @param currentFilterLevel the filter level to set ("High", "Medium", "Low", "All", or null)
+     * Sets the current filter levels.
+     * @param currentFilterLevels the set of filter levels to set ("High", "Medium", "Low") - empty set means no filter
      */
-    public void setCurrentFilterLevel(String currentFilterLevel) {
-        this.currentFilterLevel = currentFilterLevel;
+    public void setCurrentFilterLevels(java.util.Set<String> currentFilterLevels) {
+        this.currentFilterLevels = currentFilterLevels != null ? new java.util.HashSet<>(currentFilterLevels) : new java.util.HashSet<>();
     }
 
     /**
      * Checks if articles are currently filtered.
-     * @return true if filtering is active (filter level is not null and not "All"), false otherwise
+     * @return true if filtering is active (filter levels set is not empty), false otherwise
      */
     public boolean isFiltered() {
-        return currentFilterLevel != null && !"All".equalsIgnoreCase(currentFilterLevel);
+        return currentFilterLevels != null && !currentFilterLevels.isEmpty();
     }
 }

--- a/src/main/java/use_case/discover_page/DiscoverPageDataAccessInterface.java
+++ b/src/main/java/use_case/discover_page/DiscoverPageDataAccessInterface.java
@@ -11,10 +11,11 @@ import java.util.Set;
 public interface DiscoverPageDataAccessInterface {
 
     /**
-     * Gets all saved articles (reading history) from storage.
+     * Gets all saved articles (reading history) from storage for a specific user.
+     * @param username the username of the logged-in user
      * @return list of saved articles, or empty list if none exist
      */
-    List<Article> getReadingHistory();
+    List<Article> getReadingHistory(String username);
 
     /**
      * Extracts top topics from a list of articles based on word frequency in titles.

--- a/src/main/java/use_case/discover_page/DiscoverPageInputData.java
+++ b/src/main/java/use_case/discover_page/DiscoverPageInputData.java
@@ -5,10 +5,12 @@ import java.util.Set;
 public class DiscoverPageInputData {
     private final Set<String> currentTopics;
     private final int currentPage;
+    private final String username;
 
-    public DiscoverPageInputData(Set<String> currentTopics, int currentPage) {
+    public DiscoverPageInputData(Set<String> currentTopics, int currentPage, String username) {
         this.currentTopics = currentTopics;
         this.currentPage = currentPage;
+        this.username = username;
     }
 
     public Set<String> getCurrentTopics() {
@@ -17,5 +19,9 @@ public class DiscoverPageInputData {
 
     public int getCurrentPage() {
         return currentPage;
+    }
+
+    public String getUsername() {
+        return username;
     }
 }

--- a/src/main/java/use_case/discover_page/DiscoverPageInteractor.java
+++ b/src/main/java/use_case/discover_page/DiscoverPageInteractor.java
@@ -18,7 +18,8 @@ public class DiscoverPageInteractor implements DiscoverPageInputBoundary {
     @Override
     public void execute(DiscoverPageInputData inputData) {
         try {
-            List<Article> readingHistory = dataAccessObject.getReadingHistory();
+            String username = inputData.getUsername();
+            List<Article> readingHistory = dataAccessObject.getReadingHistory(username);
 
             if (readingHistory == null || readingHistory.isEmpty()) {
                 presenter.prepareNoHistoryView("Save articles to personalize your Discover feed.");

--- a/src/main/java/use_case/filter_credibility/FilterCredibilityDataAccessInterface.java
+++ b/src/main/java/use_case/filter_credibility/FilterCredibilityDataAccessInterface.java
@@ -1,4 +1,14 @@
 package use_case.filter_credibility;
 
+/**
+ * Data access interface for the filter credibility use case.
+ * Currently not needed as filtering is done in-memory,
+ * but included for consistency with the architecture pattern.
+ * 
+ * If future requirements need to persist filter preferences or
+ * retrieve filtered articles from a database, this interface can be implemented.
+ */
 public interface FilterCredibilityDataAccessInterface {
+    // No methods needed for in-memory filtering
+    // Can be extended in the future if needed
 }

--- a/src/main/java/use_case/filter_credibility/FilterCredibilityDataAccessInterface.java
+++ b/src/main/java/use_case/filter_credibility/FilterCredibilityDataAccessInterface.java
@@ -1,0 +1,4 @@
+package use_case.filter_credibility;
+
+public interface FilterCredibilityDataAccessInterface {
+}

--- a/src/main/java/use_case/filter_credibility/FilterCredibilityInputBoundary.java
+++ b/src/main/java/use_case/filter_credibility/FilterCredibilityInputBoundary.java
@@ -1,0 +1,4 @@
+package use_case.filter_credibility;
+
+public interface FilterCredibilityInputBoundary {
+}

--- a/src/main/java/use_case/filter_credibility/FilterCredibilityInputBoundary.java
+++ b/src/main/java/use_case/filter_credibility/FilterCredibilityInputBoundary.java
@@ -1,4 +1,14 @@
 package use_case.filter_credibility;
 
+/**
+ * Interface for the filter credibility use case interactor.
+ * Defines the contract for filtering articles by trust score level.
+ */
 public interface FilterCredibilityInputBoundary {
+    /**
+     * Executes the filter credibility use case.
+     * 
+     * @param inputData the input data containing articles and filter level
+     */
+    void execute(FilterCredibilityInputData inputData);
 }

--- a/src/main/java/use_case/filter_credibility/FilterCredibilityInputData.java
+++ b/src/main/java/use_case/filter_credibility/FilterCredibilityInputData.java
@@ -1,0 +1,4 @@
+package use_case.filter_credibility;
+
+public class FilterCredibilityInputData {
+}

--- a/src/main/java/use_case/filter_credibility/FilterCredibilityInputData.java
+++ b/src/main/java/use_case/filter_credibility/FilterCredibilityInputData.java
@@ -1,4 +1,26 @@
 package use_case.filter_credibility;
 
+import entity.Article;
+import java.util.List;
+
+/**
+ * Input data for filtering articles by trust score level.
+ * Contains the list of articles to filter and the desired trust level.
+ */
 public class FilterCredibilityInputData {
+    private final List<Article> articles;
+    private final String filterLevel; // "High", "Medium", "Low", or "All"/null for all articles
+
+    public FilterCredibilityInputData(List<Article> articles, String filterLevel) {
+        this.articles = articles;
+        this.filterLevel = filterLevel;
+    }
+
+    public List<Article> getArticles() {
+        return articles;
+    }
+
+    public String getFilterLevel() {
+        return filterLevel;
+    }
 }

--- a/src/main/java/use_case/filter_credibility/FilterCredibilityInputData.java
+++ b/src/main/java/use_case/filter_credibility/FilterCredibilityInputData.java
@@ -2,25 +2,26 @@ package use_case.filter_credibility;
 
 import entity.Article;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Input data for filtering articles by trust score level.
- * Contains the list of articles to filter and the desired trust level.
+ * Contains the list of articles to filter and the desired trust levels.
  */
 public class FilterCredibilityInputData {
     private final List<Article> articles;
-    private final String filterLevel; // "High", "Medium", "Low", or "All"/null for all articles
+    private final Set<String> filterLevels; // Set of "High", "Medium", "Low" - empty set means show all
 
-    public FilterCredibilityInputData(List<Article> articles, String filterLevel) {
+    public FilterCredibilityInputData(List<Article> articles, Set<String> filterLevels) {
         this.articles = articles;
-        this.filterLevel = filterLevel;
+        this.filterLevels = filterLevels;
     }
 
     public List<Article> getArticles() {
         return articles;
     }
 
-    public String getFilterLevel() {
-        return filterLevel;
+    public Set<String> getFilterLevels() {
+        return filterLevels;
     }
 }

--- a/src/main/java/use_case/filter_credibility/FilterCredibilityInteractor.java
+++ b/src/main/java/use_case/filter_credibility/FilterCredibilityInteractor.java
@@ -1,4 +1,94 @@
 package use_case.filter_credibility;
 
-public class FilterCredibilityInteractor {
+import entity.Article;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Interactor for filtering articles by trust score level.
+ * Implements the business logic for filtering articles based on their credibility scores.
+ */
+public class FilterCredibilityInteractor implements FilterCredibilityInputBoundary {
+    private final FilterCredibilityOutputBoundary presenter;
+
+    public FilterCredibilityInteractor(FilterCredibilityOutputBoundary presenter) {
+        this.presenter = presenter;
+    }
+
+    @Override
+    public void execute(FilterCredibilityInputData inputData) {
+        List<Article> articles = inputData.getArticles();
+        String filterLevel = inputData.getFilterLevel();
+
+        // Alternative Flow 1: Check if all articles have trust scores
+        if (!allArticlesHaveScores(articles)) {
+            presenter.presentError("Generate all scores to filter.");
+            return;
+        }
+
+        // If filterLevel is "All" or null, return all articles
+        if (filterLevel == null || "All".equalsIgnoreCase(filterLevel)) {
+            FilterCredibilityOutputData outputData = new FilterCredibilityOutputData(articles, "All");
+            presenter.presentSuccess(outputData);
+            return;
+        }
+
+        // Filter articles by the selected trust level
+        List<Article> filteredArticles = filterByLevel(articles, filterLevel);
+
+        // Alternative Flow 2: Check if any articles match the filter
+        if (filteredArticles.isEmpty()) {
+            presenter.presentError("No articles found at this trust level.");
+            return;
+        }
+
+        // Main Flow: Successfully filtered articles
+        FilterCredibilityOutputData outputData = new FilterCredibilityOutputData(filteredArticles, filterLevel);
+        presenter.presentSuccess(outputData);
+    }
+
+    /**
+     * Checks if all articles have generated credibility scores.
+     * An article has a score if it has a non-null credibilityScore and
+     * a confidenceLevel that is not "Unknown".
+     * 
+     * @param articles the list of articles to check
+     * @return true if all articles have scores, false otherwise
+     */
+    private boolean allArticlesHaveScores(List<Article> articles) {
+        if (articles == null || articles.isEmpty()) {
+            return false;
+        }
+
+        for (Article article : articles) {
+            if (article.getCredibilityScore() == null) {
+                return false;
+            }
+            String level = article.getConfidenceLevel();
+            if (level == null || "Unknown".equalsIgnoreCase(level)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Filters articles by the specified trust level.
+     * 
+     * @param articles the list of articles to filter
+     * @param filterLevel the trust level to filter by ("High", "Medium", or "Low")
+     * @return a list of articles matching the filter level
+     */
+    private List<Article> filterByLevel(List<Article> articles, String filterLevel) {
+        List<Article> filtered = new ArrayList<>();
+        
+        for (Article article : articles) {
+            String articleLevel = article.getConfidenceLevel();
+            if (articleLevel != null && articleLevel.equalsIgnoreCase(filterLevel)) {
+                filtered.add(article);
+            }
+        }
+        
+        return filtered;
+    }
 }

--- a/src/main/java/use_case/filter_credibility/FilterCredibilityInteractor.java
+++ b/src/main/java/use_case/filter_credibility/FilterCredibilityInteractor.java
@@ -1,0 +1,4 @@
+package use_case.filter_credibility;
+
+public class FilterCredibilityInteractor {
+}

--- a/src/main/java/use_case/filter_credibility/FilterCredibilityOutputBoundary.java
+++ b/src/main/java/use_case/filter_credibility/FilterCredibilityOutputBoundary.java
@@ -1,0 +1,4 @@
+package use_case.filter_credibility;
+
+public interface FilterCredibilityOutputBoundary {
+}

--- a/src/main/java/use_case/filter_credibility/FilterCredibilityOutputBoundary.java
+++ b/src/main/java/use_case/filter_credibility/FilterCredibilityOutputBoundary.java
@@ -1,4 +1,21 @@
 package use_case.filter_credibility;
 
+/**
+ * Interface for the output boundary of the filter credibility use case.
+ * Implemented by the presenter to handle success and error cases.
+ */
 public interface FilterCredibilityOutputBoundary {
+    /**
+     * Presents the successfully filtered articles.
+     * 
+     * @param outputData the output data containing filtered articles
+     */
+    void presentSuccess(FilterCredibilityOutputData outputData);
+
+    /**
+     * Presents an error message when filtering fails.
+     * 
+     * @param errorMessage the error message to display
+     */
+    void presentError(String errorMessage);
 }

--- a/src/main/java/use_case/filter_credibility/FilterCredibilityOutputData.java
+++ b/src/main/java/use_case/filter_credibility/FilterCredibilityOutputData.java
@@ -1,4 +1,26 @@
 package use_case.filter_credibility;
 
+import entity.Article;
+import java.util.List;
+
+/**
+ * Output data for the filter credibility use case.
+ * Contains the filtered articles and the filter level that was applied.
+ */
 public class FilterCredibilityOutputData {
+    private final List<Article> filteredArticles;
+    private final String filterLevel;
+
+    public FilterCredibilityOutputData(List<Article> filteredArticles, String filterLevel) {
+        this.filteredArticles = filteredArticles;
+        this.filterLevel = filterLevel;
+    }
+
+    public List<Article> getFilteredArticles() {
+        return filteredArticles;
+    }
+
+    public String getFilterLevel() {
+        return filterLevel;
+    }
 }

--- a/src/main/java/use_case/filter_credibility/FilterCredibilityOutputData.java
+++ b/src/main/java/use_case/filter_credibility/FilterCredibilityOutputData.java
@@ -2,25 +2,26 @@ package use_case.filter_credibility;
 
 import entity.Article;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Output data for the filter credibility use case.
- * Contains the filtered articles and the filter level that was applied.
+ * Contains the filtered articles and the filter levels that were applied.
  */
 public class FilterCredibilityOutputData {
     private final List<Article> filteredArticles;
-    private final String filterLevel;
+    private final Set<String> filterLevels;
 
-    public FilterCredibilityOutputData(List<Article> filteredArticles, String filterLevel) {
+    public FilterCredibilityOutputData(List<Article> filteredArticles, Set<String> filterLevels) {
         this.filteredArticles = filteredArticles;
-        this.filterLevel = filterLevel;
+        this.filterLevels = filterLevels;
     }
 
     public List<Article> getFilteredArticles() {
         return filteredArticles;
     }
 
-    public String getFilterLevel() {
-        return filterLevel;
+    public Set<String> getFilterLevels() {
+        return filterLevels;
     }
 }

--- a/src/main/java/use_case/filter_credibility/FilterCredibilityOutputData.java
+++ b/src/main/java/use_case/filter_credibility/FilterCredibilityOutputData.java
@@ -1,0 +1,4 @@
+package use_case.filter_credibility;
+
+public class FilterCredibilityOutputData {
+}

--- a/src/main/java/view/DiscoverPageView.java
+++ b/src/main/java/view/DiscoverPageView.java
@@ -244,10 +244,37 @@ public class DiscoverPageView extends JPanel implements PropertyChangeListener {
         filterDialog.setSize(400, 250);
         filterDialog.setLocationRelativeTo(this);
 
-        // Create header label
+        // Create header panel with label and info button
+        JPanel headerPanel = new JPanel();
+        headerPanel.setLayout(new BoxLayout(headerPanel, BoxLayout.X_AXIS));
+        headerPanel.setBorder(BorderFactory.createEmptyBorder(15, 20, 10, 20));
+        headerPanel.setBackground(Color.WHITE);
+        headerPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        
         JLabel headerLabel = new JLabel("Filter articles based on credibility score:");
         headerLabel.setFont(new Font("TimesNewRoman", Font.BOLD, 14));
-        headerLabel.setBorder(BorderFactory.createEmptyBorder(15, 20, 10, 20));
+        headerLabel.setAlignmentY(Component.CENTER_ALIGNMENT);
+        
+        JLabel infoLabel = new JLabel("ⓘ");
+        infoLabel.setFont(new Font("TimesNewRoman", Font.PLAIN, 16));
+        infoLabel.setForeground(new Color(100, 100, 200)); // Blue-ish color for info
+        infoLabel.setCursor(new Cursor(Cursor.HAND_CURSOR));
+        infoLabel.setAlignmentY(Component.CENTER_ALIGNMENT);
+        infoLabel.addMouseListener(new java.awt.event.MouseAdapter() {
+            @Override
+            public void mouseClicked(java.awt.event.MouseEvent e) {
+                JOptionPane.showMessageDialog(
+                        filterDialog,
+                        "High: overallTrust >= 0.8\nMedium: overallTrust >= 0.65\nLow: overallTrust < 0.65",
+                        "Trust Score Thresholds",
+                        JOptionPane.INFORMATION_MESSAGE
+                );
+            }
+        });
+        
+        headerPanel.add(headerLabel);
+        headerPanel.add(Box.createHorizontalStrut(3)); // Small gap
+        headerPanel.add(infoLabel);
 
         // Create checkboxes with color icons
         JCheckBox highCheckBox = new JCheckBox("🟢 High Trust");
@@ -276,7 +303,7 @@ public class DiscoverPageView extends JPanel implements PropertyChangeListener {
         buttonPanel.add(applyButton);
         buttonPanel.add(clearButton);
 
-        filterDialog.add(headerLabel, BorderLayout.NORTH);
+        filterDialog.add(headerPanel, BorderLayout.NORTH);
         filterDialog.add(checkboxPanel, BorderLayout.CENTER);
         filterDialog.add(buttonPanel, BorderLayout.SOUTH);
 

--- a/src/main/java/view/DiscoverPageView.java
+++ b/src/main/java/view/DiscoverPageView.java
@@ -167,7 +167,17 @@ public class DiscoverPageView extends JPanel implements PropertyChangeListener {
 
     public void setController(DiscoverPageController controller) {
         this.controller = controller;
-        if (controller != null) {
+    }
+
+    /**
+     * Loads articles when the view becomes visible.
+     * This ensures articles are loaded after the user has logged in.
+     */
+    @Override
+    public void setVisible(boolean visible) {
+        super.setVisible(visible);
+        if (visible && controller != null) {
+            // Load articles when view becomes visible (after login)
             controller.execute();
         }
     }

--- a/src/main/java/view/DiscoverPageView.java
+++ b/src/main/java/view/DiscoverPageView.java
@@ -39,8 +39,7 @@ public class DiscoverPageView extends JPanel implements PropertyChangeListener {
     private final JButton generateAllCredibilityButton = new JButton("Generate All Scores");
     private final JButton viewDetailsButton = new JButton("View Details");
     // Filter by trust score
-    private final JLabel filterLabel = new JLabel("Filter by Trust Score:");
-    private final JComboBox<String> filterComboBox = new JComboBox<>(new String[]{"All", "High", "Medium", "Low"});
+    private final JButton filterButton = new JButton("Filter by Credibility");
     private final JLabel messageLabel = new JLabel();
     private final JPanel messagePanel = new JPanel();
     private final JPanel centerPanel = new JPanel(new CardLayout());
@@ -56,7 +55,7 @@ public class DiscoverPageView extends JPanel implements PropertyChangeListener {
         JPanel topBar = new JPanel(new FlowLayout(FlowLayout.CENTER, 10, 10));
         JLabel title = new JLabel("Discover Page");
         title.setFont(new Font("TimesNewRoman", Font.BOLD, 22));
-        JLabel subtitle = new JLabel("Articles based on your saved articles");
+        JLabel subtitle = new JLabel("Displaying new articles based on your saved articles");
         subtitle.setFont(new Font("TimesNewRoman", Font.PLAIN, 12));
         subtitle.setForeground(new Color(100, 100, 100));
         topBar.add(title);
@@ -65,8 +64,7 @@ public class DiscoverPageView extends JPanel implements PropertyChangeListener {
         topBar.add(generateCredibilityButton);
         topBar.add(generateAllCredibilityButton);
         topBar.add(viewDetailsButton);
-        topBar.add(filterLabel);
-        topBar.add(filterComboBox);
+        topBar.add(filterButton);
         topBar.setBackground(Color.WHITE);
 
         JPanel topPanel = new JPanel();
@@ -158,37 +156,27 @@ public class DiscoverPageView extends JPanel implements PropertyChangeListener {
         });
 
         // Filter by trust score
-        filterComboBox.addActionListener(e -> {
+        filterButton.addActionListener(e -> {
             if (filterCredibilityController == null) {
-                return; // Filter feature not available yet
-            }
-            String selectedLevel = (String) filterComboBox.getSelectedItem();
-            if (selectedLevel == null) {
+                JOptionPane.showMessageDialog(this, "Filter feature not available.");
                 return;
             }
 
             var state = viewModel.getState();
             List<Article> currentArticles = state.getArticles();
 
-            // Store original articles if not already stored or if we're switching from filtered to unfiltered
-            if (state.getOriginalArticles().isEmpty() && !currentArticles.isEmpty()) {
-                state.setOriginalArticles(currentArticles);
+            if (currentArticles.isEmpty()) {
+                JOptionPane.showMessageDialog(this, "No articles to filter.");
+                return;
             }
 
-            // If "All" is selected, restore original articles
-            if ("All".equals(selectedLevel)) {
-                List<Article> originalArticles = state.getOriginalArticles();
-                if (!originalArticles.isEmpty()) {
-                    state.setArticles(new ArrayList<>(originalArticles));
-                    state.setCurrentFilterLevel(null);
-                    viewModel.firePropertyChange();
-                }
-            } else {
-                // Filter articles by the selected level
-                if (!currentArticles.isEmpty()) {
-                    filterCredibilityController.filterArticles(currentArticles, selectedLevel);
-                }
+            // Store original articles if not already stored
+            if (state.getOriginalArticles().isEmpty()) {
+                state.setOriginalArticles(new ArrayList<>(currentArticles));
             }
+
+            // Create filter dialog
+            showFilterDialog();
         });
 
         articleList.addMouseListener(new MouseAdapter() {
@@ -246,17 +234,89 @@ public class DiscoverPageView extends JPanel implements PropertyChangeListener {
         }
     }
 
+    private void showFilterDialog() {
+        var state = viewModel.getState();
+        java.util.Set<String> currentFilterLevels = state.getCurrentFilterLevels();
+
+        // Create dialog
+        JDialog filterDialog = new JDialog((JFrame) SwingUtilities.getWindowAncestor(this), "Filter by Credibility", true);
+        filterDialog.setLayout(new BorderLayout(10, 10));
+        filterDialog.setSize(400, 250);
+        filterDialog.setLocationRelativeTo(this);
+
+        // Create header label
+        JLabel headerLabel = new JLabel("Filter articles based on credibility score:");
+        headerLabel.setFont(new Font("TimesNewRoman", Font.BOLD, 14));
+        headerLabel.setBorder(BorderFactory.createEmptyBorder(15, 20, 10, 20));
+
+        // Create checkboxes with color icons
+        JCheckBox highCheckBox = new JCheckBox("🟢 High Trust");
+        JCheckBox mediumCheckBox = new JCheckBox("🟡 Medium Trust");
+        JCheckBox lowCheckBox = new JCheckBox("🔴 Low Trust");
+
+        // Pre-select based on current filter state
+        highCheckBox.setSelected(currentFilterLevels.contains("High"));
+        mediumCheckBox.setSelected(currentFilterLevels.contains("Medium"));
+        lowCheckBox.setSelected(currentFilterLevels.contains("Low"));
+
+        // Create checkbox panel
+        JPanel checkboxPanel = new JPanel();
+        checkboxPanel.setLayout(new BoxLayout(checkboxPanel, BoxLayout.Y_AXIS));
+        checkboxPanel.setBorder(BorderFactory.createEmptyBorder(10, 20, 20, 20));
+        checkboxPanel.add(highCheckBox);
+        checkboxPanel.add(Box.createVerticalStrut(10));
+        checkboxPanel.add(mediumCheckBox);
+        checkboxPanel.add(Box.createVerticalStrut(10));
+        checkboxPanel.add(lowCheckBox);
+
+        // Create button panel
+        JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.CENTER, 10, 10));
+        JButton applyButton = new JButton("Apply Filter");
+        JButton clearButton = new JButton("Clear Filter");
+        buttonPanel.add(applyButton);
+        buttonPanel.add(clearButton);
+
+        filterDialog.add(headerLabel, BorderLayout.NORTH);
+        filterDialog.add(checkboxPanel, BorderLayout.CENTER);
+        filterDialog.add(buttonPanel, BorderLayout.SOUTH);
+
+        // Apply button action
+        applyButton.addActionListener(e -> {
+            java.util.Set<String> selectedLevels = new java.util.HashSet<>();
+            if (highCheckBox.isSelected()) {
+                selectedLevels.add("High");
+            }
+            if (mediumCheckBox.isSelected()) {
+                selectedLevels.add("Medium");
+            }
+            if (lowCheckBox.isSelected()) {
+                selectedLevels.add("Low");
+            }
+
+            List<Article> currentArticles = state.getArticles();
+            if (!currentArticles.isEmpty()) {
+                filterCredibilityController.filterArticles(currentArticles, selectedLevels);
+            }
+            filterDialog.dispose();
+        });
+
+        // Clear button action
+        clearButton.addActionListener(e -> {
+            List<Article> originalArticles = state.getOriginalArticles();
+            if (!originalArticles.isEmpty()) {
+                state.setArticles(new ArrayList<>(originalArticles));
+                state.setCurrentFilterLevels(new java.util.HashSet<>());
+                viewModel.firePropertyChange();
+            }
+            filterDialog.dispose();
+        });
+
+        filterDialog.setVisible(true);
+    }
+
     private void updateView() {
         var state = viewModel.getState();
         CardLayout cardLayout = (CardLayout) centerPanel.getLayout();
-
-        // Sync filter combo box with state
-        String currentFilterLevel = state.getCurrentFilterLevel();
-        if (currentFilterLevel == null || "All".equals(currentFilterLevel)) {
-            filterComboBox.setSelectedItem("All");
-        } else {
-            filterComboBox.setSelectedItem(currentFilterLevel);
-        }
 
         if (state.getHasNoHistory() || state.getHasNoArticles()) {
             messageLabel.setText(state.getMessage());
@@ -282,6 +342,20 @@ public class DiscoverPageView extends JPanel implements PropertyChangeListener {
         int selectedIndex = articleList.getSelectedIndex();
 
         updateView();
+
+        // Show error message in popup if there's a filter error (message set but articles should remain visible)
+        var state = viewModel.getState();
+        String message = state.getMessage();
+        // If message exists but hasNoHistory and hasNoArticles are both false, it's a filter error
+        // Show popup and keep articles visible (like TopHeadlinesView does)
+        if (message != null && !message.isEmpty() && !state.getHasNoHistory() && !state.getHasNoArticles()) {
+            JOptionPane.showMessageDialog(
+                    this,
+                    message,
+                    "Filter Error",
+                    JOptionPane.INFORMATION_MESSAGE);
+            state.setMessage(null); // Clear the message after showing
+        }
 
         if (selectedIndex >= 0 && selectedIndex < listModel.getSize()) {
             articleList.setSelectedIndex(selectedIndex);

--- a/src/main/java/view/DiscoverPageView.java
+++ b/src/main/java/view/DiscoverPageView.java
@@ -6,6 +6,7 @@ import interface_adapter.discover_page.DiscoverPageController;
 import interface_adapter.discover_page.DiscoverPageViewModel;
 
 import interface_adapter.generate_credibility.GenerateCredibilityController;
+import interface_adapter.filter_credibility.FilterCredibilityController;
 import interface_adapter.view_credibility.ViewCredibilityDetailsViewModel;
 import interface_adapter.view_credibility.ViewCredibilityDetailsController;
 
@@ -29,6 +30,7 @@ public class DiscoverPageView extends JPanel implements PropertyChangeListener {
     private GenerateCredibilityController generateCredibilityController;
     private ViewCredibilityDetailsController viewCredibilityDetailsController;
     private ViewCredibilityDetailsViewModel viewCredibilityDetailsViewModel;
+    private FilterCredibilityController filterCredibilityController;
     private final DefaultListModel<Article> listModel = new DefaultListModel<>();
     private final JList<Article> articleList = new JList<>(listModel);
     private final JButton refreshButton = new JButton("Refresh Discover Feed");
@@ -192,6 +194,10 @@ public class DiscoverPageView extends JPanel implements PropertyChangeListener {
         this.generateCredibilityController = generateController;
         this.viewCredibilityDetailsController = detailsController;
         this.viewCredibilityDetailsViewModel = detailsViewModel;
+    }
+
+    public void setFilterCredibilityController(FilterCredibilityController filterCredibilityController) {
+        this.filterCredibilityController = filterCredibilityController;
     }
 
     private void openInBrowser(String url) {

--- a/src/main/java/view/TopHeadlinesView.java
+++ b/src/main/java/view/TopHeadlinesView.java
@@ -418,10 +418,37 @@ public class TopHeadlinesView extends JPanel implements PropertyChangeListener {
         filterDialog.setSize(400, 250);
         filterDialog.setLocationRelativeTo(this);
 
-        // Create header label
+        // Create header panel with label and info button
+        JPanel headerPanel = new JPanel();
+        headerPanel.setLayout(new BoxLayout(headerPanel, BoxLayout.X_AXIS));
+        headerPanel.setBorder(BorderFactory.createEmptyBorder(15, 20, 10, 20));
+        headerPanel.setBackground(Color.WHITE);
+        headerPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        
         JLabel headerLabel = new JLabel("Filter articles based on credibility score:");
         headerLabel.setFont(new Font("TimesNewRoman", Font.BOLD, 14));
-        headerLabel.setBorder(BorderFactory.createEmptyBorder(15, 20, 10, 20));
+        headerLabel.setAlignmentY(Component.CENTER_ALIGNMENT);
+        
+        JLabel infoLabel = new JLabel("ⓘ");
+        infoLabel.setFont(new Font("TimesNewRoman", Font.PLAIN, 16));
+        infoLabel.setForeground(new Color(100, 100, 200)); // Blue-ish color for info
+        infoLabel.setCursor(new Cursor(Cursor.HAND_CURSOR));
+        infoLabel.setAlignmentY(Component.CENTER_ALIGNMENT);
+        infoLabel.addMouseListener(new java.awt.event.MouseAdapter() {
+            @Override
+            public void mouseClicked(java.awt.event.MouseEvent e) {
+                JOptionPane.showMessageDialog(
+                        filterDialog,
+                        "High: overallTrust >= 0.8\nMedium: overallTrust >= 0.65\nLow: overallTrust < 0.65",
+                        "Trust Score Thresholds",
+                        JOptionPane.INFORMATION_MESSAGE
+                );
+            }
+        });
+        
+        headerPanel.add(headerLabel);
+        headerPanel.add(Box.createHorizontalStrut(3)); // Small gap
+        headerPanel.add(infoLabel);
 
         // Create checkboxes with color icons
         JCheckBox highCheckBox = new JCheckBox("🟢 High Trust");
@@ -450,7 +477,7 @@ public class TopHeadlinesView extends JPanel implements PropertyChangeListener {
         buttonPanel.add(applyButton);
         buttonPanel.add(clearButton);
 
-        filterDialog.add(headerLabel, BorderLayout.NORTH);
+        filterDialog.add(headerPanel, BorderLayout.NORTH);
         filterDialog.add(checkboxPanel, BorderLayout.CENTER);
         filterDialog.add(buttonPanel, BorderLayout.SOUTH);
 

--- a/src/main/java/view/TopHeadlinesView.java
+++ b/src/main/java/view/TopHeadlinesView.java
@@ -11,6 +11,7 @@ import interface_adapter.save_article.SaveArticleController;
 import interface_adapter.save_article.SaveArticleViewModel;
 
 import interface_adapter.generate_credibility.GenerateCredibilityController;
+import interface_adapter.filter_credibility.FilterCredibilityController;
 import interface_adapter.view_credibility.ViewCredibilityDetailsState;
 import interface_adapter.view_credibility.ViewCredibilityDetailsViewModel;
 import interface_adapter.view_credibility.ViewCredibilityDetailsController;
@@ -45,6 +46,7 @@ public class TopHeadlinesView extends JPanel implements PropertyChangeListener {
     private GenerateCredibilityController generateCredibilityController;
     private ViewCredibilityDetailsController viewCredibilityDetailsController;
     private ViewCredibilityDetailsViewModel viewCredibilityDetailsViewModel;
+    private FilterCredibilityController filterCredibilityController;
 
     private final DefaultListModel<Article> listModel = new DefaultListModel<>();
     private final JList<Article> articleList = new JList<>(listModel);
@@ -283,6 +285,9 @@ public class TopHeadlinesView extends JPanel implements PropertyChangeListener {
         });
     }
 
+    public void setFilterCredibilityController(FilterCredibilityController filterCredibilityController) {
+        this.filterCredibilityController = filterCredibilityController;
+    }
 
     private void loadArticles() {
         if (controller != null) {

--- a/src/test/java/use_case/discover_page/DiscoverPageInteractorTest.java
+++ b/src/test/java/use_case/discover_page/DiscoverPageInteractorTest.java
@@ -34,7 +34,7 @@ class DiscoverPageInteractorTest {
         }
 
         @Override
-        public List<Article> getReadingHistory() {
+        public List<Article> getReadingHistory(String username) {
             return readingHistory;
         }
 
@@ -70,7 +70,7 @@ class DiscoverPageInteractorTest {
         TestDiscoverPageDAO dao = new TestDiscoverPageDAO(readingHistory, topics, discoveredArticles, null);
         
         // Current topics are different (or null)
-        DiscoverPageInputData input = new DiscoverPageInputData(null, 0);
+        DiscoverPageInputData input = new DiscoverPageInputData(null, 0, "testUser");
 
         DiscoverPageOutputBoundary presenter = new DiscoverPageOutputBoundary() {
             @Override
@@ -110,7 +110,7 @@ class DiscoverPageInteractorTest {
         TestDiscoverPageDAO dao = new TestDiscoverPageDAO(readingHistory, topics, discoveredArticles, null);
         
         // Current topics are the same
-        DiscoverPageInputData input = new DiscoverPageInputData(topics, 0);
+        DiscoverPageInputData input = new DiscoverPageInputData(topics, 0, "testUser");
 
         DiscoverPageOutputBoundary presenter = new DiscoverPageOutputBoundary() {
             @Override
@@ -138,7 +138,7 @@ class DiscoverPageInteractorTest {
     @Test
     void failure_noReadingHistory() {
         TestDiscoverPageDAO dao = new TestDiscoverPageDAO(new ArrayList<>(), new HashSet<>(), new ArrayList<>(), null);
-        DiscoverPageInputData input = new DiscoverPageInputData(null, 0);
+        DiscoverPageInputData input = new DiscoverPageInputData(null, 0, "testUser");
 
         DiscoverPageOutputBoundary presenter = new DiscoverPageOutputBoundary() {
             @Override
@@ -167,7 +167,7 @@ class DiscoverPageInteractorTest {
         readingHistory.add(new Article("1", "The a an", "d", "l1", "i1", "s1")); // Only stop words
 
         TestDiscoverPageDAO dao = new TestDiscoverPageDAO(readingHistory, new HashSet<>(), new ArrayList<>(), null);
-        DiscoverPageInputData input = new DiscoverPageInputData(null, 0);
+        DiscoverPageInputData input = new DiscoverPageInputData(null, 0, "testUser");
 
         DiscoverPageOutputBoundary presenter = new DiscoverPageOutputBoundary() {
             @Override
@@ -203,7 +203,7 @@ class DiscoverPageInteractorTest {
 
         // No articles on page 1, but articles on page 0
         TestDiscoverPageDAO dao = new TestDiscoverPageDAO(readingHistory, topics, new ArrayList<>(), page0Articles);
-        DiscoverPageInputData input = new DiscoverPageInputData(topics, 0); // Will try page 1, then fallback to 0
+        DiscoverPageInputData input = new DiscoverPageInputData(topics, 0, "testUser"); // Will try page 1, then fallback to 0
 
         DiscoverPageOutputBoundary presenter = new DiscoverPageOutputBoundary() {
             @Override
@@ -237,7 +237,7 @@ class DiscoverPageInteractorTest {
 
         // No articles on any page
         TestDiscoverPageDAO dao = new TestDiscoverPageDAO(readingHistory, topics, new ArrayList<>(), new ArrayList<>());
-        DiscoverPageInputData input = new DiscoverPageInputData(null, 0);
+        DiscoverPageInputData input = new DiscoverPageInputData(null, 0, "testUser");
 
         DiscoverPageOutputBoundary presenter = new DiscoverPageOutputBoundary() {
             @Override
@@ -265,7 +265,7 @@ class DiscoverPageInteractorTest {
         // DAO that throws exception
         DiscoverPageDataAccessInterface dao = new DiscoverPageDataAccessInterface() {
             @Override
-            public List<Article> getReadingHistory() {
+            public List<Article> getReadingHistory(String username) {
                 throw new RuntimeException("Database error");
             }
 
@@ -280,7 +280,7 @@ class DiscoverPageInteractorTest {
             }
         };
 
-        DiscoverPageInputData input = new DiscoverPageInputData(null, 0);
+        DiscoverPageInputData input = new DiscoverPageInputData(null, 0, "testUser");
 
         DiscoverPageOutputBoundary presenter = new DiscoverPageOutputBoundary() {
             @Override

--- a/src/test/java/use_case/filter_credibility/FilterCredibilityInteractorTest.java
+++ b/src/test/java/use_case/filter_credibility/FilterCredibilityInteractorTest.java
@@ -1,0 +1,4 @@
+package use_case.filter_credibility;
+
+public class FilterCredibilityInteractorTest {
+}

--- a/src/test/java/use_case/filter_credibility/FilterCredibilityInteractorTest.java
+++ b/src/test/java/use_case/filter_credibility/FilterCredibilityInteractorTest.java
@@ -1,4 +1,344 @@
 package use_case.filter_credibility;
 
-public class FilterCredibilityInteractorTest {
+import entity.Article;
+import entity.CredibilityScore;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for FilterCredibilityInteractor
+ */
+class FilterCredibilityInteractorTest {
+
+    private Article createArticleWithScore(String id, String title, String level) {
+        
+        double sourceScore, sentimentScore, claimConfidence;
+        
+        if ("High".equals(level)) {
+            sourceScore = 0.8;
+            sentimentScore = 0.9;
+            claimConfidence = 0.9;
+        } else if ("Medium".equals(level)) {
+            sourceScore = 0.5;
+            sentimentScore = 0.7;
+            claimConfidence = 0.7;
+        } else {
+            sourceScore = 0.3;
+            sentimentScore = 0.4;
+            claimConfidence = 0.4;
+        }
+        
+        CredibilityScore credibilityScore = new CredibilityScore(sourceScore, sentimentScore, claimConfidence);
+        Article article = new Article(id, title, "description", "url", "imageUrl", "source");
+        article.setCredibilityScore(credibilityScore);
+        article.setConfidenceLevel(credibilityScore.getLevel());
+        article.setTrustScore(credibilityScore.getOverallTrust());
+        
+        return article;
+    }
+
+    @Test
+    void success_filterByHighTrust() {
+
+        List<Article> articles = new ArrayList<>();
+        articles.add(createArticleWithScore("1", "High Trust Article", "High"));
+        articles.add(createArticleWithScore("2", "Medium Trust Article", "Medium"));
+        articles.add(createArticleWithScore("3", "Low Trust Article", "Low"));
+        articles.add(createArticleWithScore("4", "Another High Trust Article", "High"));
+
+        Set<String> filterLevels = new HashSet<>();
+        filterLevels.add("High");
+
+        FilterCredibilityOutputBoundary presenter = new FilterCredibilityOutputBoundary() {
+            @Override
+            public void presentSuccess(FilterCredibilityOutputData output) {
+                assertEquals(2, output.getFilteredArticles().size());
+                assertEquals(filterLevels, output.getFilterLevels());
+                // Verify all filtered articles are High trust
+                for (Article article : output.getFilteredArticles()) {
+                    assertEquals("High", article.getConfidenceLevel());
+                }
+            }
+
+            @Override
+            public void presentError(String errorMessage) {
+                fail("Should not present error when filtering succeeds.");
+            }
+        };
+
+        FilterCredibilityInteractor interactor = new FilterCredibilityInteractor(presenter);
+        FilterCredibilityInputData inputData = new FilterCredibilityInputData(articles, filterLevels);
+        interactor.execute(inputData);
+    }
+
+    @Test
+    void success_filterByMultipleLevels() {
+
+        List<Article> articles = new ArrayList<>();
+        articles.add(createArticleWithScore("1", "High Trust Article", "High"));
+        articles.add(createArticleWithScore("2", "Medium Trust Article", "Medium"));
+        articles.add(createArticleWithScore("3", "Low Trust Article", "Low"));
+        articles.add(createArticleWithScore("4", "Another High Trust Article", "High"));
+        articles.add(createArticleWithScore("5", "Another Medium Trust Article", "Medium"));
+
+        Set<String> filterLevels = new HashSet<>();
+        filterLevels.add("High");
+        filterLevels.add("Medium");
+
+        FilterCredibilityOutputBoundary presenter = new FilterCredibilityOutputBoundary() {
+            @Override
+            public void presentSuccess(FilterCredibilityOutputData output) {
+                assertEquals(4, output.getFilteredArticles().size());
+                assertEquals(filterLevels, output.getFilterLevels());
+                // Verify all filtered articles are High or Medium trust
+                for (Article article : output.getFilteredArticles()) {
+                    String level = article.getConfidenceLevel();
+                    assertTrue("High".equals(level) || "Medium".equals(level),
+                            "Article should be High or Medium trust");
+                }
+            }
+
+            @Override
+            public void presentError(String errorMessage) {
+                fail("Should not present error when filtering succeeds.");
+            }
+        };
+
+        FilterCredibilityInteractor interactor = new FilterCredibilityInteractor(presenter);
+        FilterCredibilityInputData inputData = new FilterCredibilityInputData(articles, filterLevels);
+        interactor.execute(inputData);
+    }
+
+    @Test
+    void success_emptyFilterLevels_returnsAllArticles() {
+
+        List<Article> articles = new ArrayList<>();
+        articles.add(createArticleWithScore("1", "High Trust Article", "High"));
+        articles.add(createArticleWithScore("2", "Medium Trust Article", "Medium"));
+        articles.add(createArticleWithScore("3", "Low Trust Article", "Low"));
+
+        Set<String> filterLevels = new HashSet<>(); // Empty set
+
+        FilterCredibilityOutputBoundary presenter = new FilterCredibilityOutputBoundary() {
+            @Override
+            public void presentSuccess(FilterCredibilityOutputData output) {
+                assertEquals(3, output.getFilteredArticles().size());
+                assertTrue(output.getFilterLevels().isEmpty());
+
+                assertEquals(articles, output.getFilteredArticles());
+            }
+
+            @Override
+            public void presentError(String errorMessage) {
+                fail("Should not present error when filter levels are empty.");
+            }
+        };
+
+        FilterCredibilityInteractor interactor = new FilterCredibilityInteractor(presenter);
+        FilterCredibilityInputData inputData = new FilterCredibilityInputData(articles, filterLevels);
+        interactor.execute(inputData);
+    }
+
+    @Test
+    void success_nullFilterLevels_returnsAllArticles() {
+
+        List<Article> articles = new ArrayList<>();
+        articles.add(createArticleWithScore("1", "High Trust Article", "High"));
+        articles.add(createArticleWithScore("2", "Medium Trust Article", "Medium"));
+
+        FilterCredibilityOutputBoundary presenter = new FilterCredibilityOutputBoundary() {
+            @Override
+            public void presentSuccess(FilterCredibilityOutputData output) {
+                assertEquals(2, output.getFilteredArticles().size());
+                assertTrue(output.getFilterLevels().isEmpty());
+            }
+
+            @Override
+            public void presentError(String errorMessage) {
+                fail("Should not present error when filter levels are null.");
+            }
+        };
+
+        FilterCredibilityInteractor interactor = new FilterCredibilityInteractor(presenter);
+        FilterCredibilityInputData inputData = new FilterCredibilityInputData(articles, null);
+        interactor.execute(inputData);
+    }
+
+    @Test
+    void error_notAllArticlesHaveScores() {
+        List<Article> articles = new ArrayList<>();
+        articles.add(createArticleWithScore("1", "Article with score", "High"));
+        
+
+        Article articleWithoutScore = new Article("2", "Article without score", "d", "url", "img", "source");
+        articles.add(articleWithoutScore);
+
+        Set<String> filterLevels = new HashSet<>();
+        filterLevels.add("High");
+
+        FilterCredibilityOutputBoundary presenter = new FilterCredibilityOutputBoundary() {
+            @Override
+            public void presentSuccess(FilterCredibilityOutputData output) {
+                fail("Should not present success when not all articles have scores.");
+            }
+
+            @Override
+            public void presentError(String errorMessage) {
+                assertEquals("Generate all scores to filter.", errorMessage);
+            }
+        };
+
+        FilterCredibilityInteractor interactor = new FilterCredibilityInteractor(presenter);
+        FilterCredibilityInputData inputData = new FilterCredibilityInputData(articles, filterLevels);
+        interactor.execute(inputData);
+    }
+
+    @Test
+    void error_articleWithUnknownLevel() {
+        List<Article> articles = new ArrayList<>();
+        articles.add(createArticleWithScore("1", "Article with score", "High"));
+        
+
+        Article articleWithUnknown = new Article("2", "Article with unknown", "d", "url", "img", "source");
+        CredibilityScore score = new CredibilityScore(0.5, 0.5, 0.5);
+        articleWithUnknown.setCredibilityScore(score);
+        articleWithUnknown.setConfidenceLevel("Unknown");
+        articles.add(articleWithUnknown);
+
+        Set<String> filterLevels = new HashSet<>();
+        filterLevels.add("High");
+
+        FilterCredibilityOutputBoundary presenter = new FilterCredibilityOutputBoundary() {
+            @Override
+            public void presentSuccess(FilterCredibilityOutputData output) {
+                fail("Should not present success when article has Unknown level.");
+            }
+
+            @Override
+            public void presentError(String errorMessage) {
+                assertEquals("Generate all scores to filter.", errorMessage);
+            }
+        };
+
+        FilterCredibilityInteractor interactor = new FilterCredibilityInteractor(presenter);
+        FilterCredibilityInputData inputData = new FilterCredibilityInputData(articles, filterLevels);
+        interactor.execute(inputData);
+    }
+
+    @Test
+    void error_noArticlesMatchFilter() {
+
+        List<Article> articles = new ArrayList<>();
+        articles.add(createArticleWithScore("1", "High Trust Article", "High"));
+        articles.add(createArticleWithScore("2", "Medium Trust Article", "Medium"));
+
+        Set<String> filterLevels = new HashSet<>();
+        filterLevels.add("Low");
+
+        FilterCredibilityOutputBoundary presenter = new FilterCredibilityOutputBoundary() {
+            @Override
+            public void presentSuccess(FilterCredibilityOutputData output) {
+                fail("Should not present success when no articles match the filter.");
+            }
+
+            @Override
+            public void presentError(String errorMessage) {
+                assertEquals("No articles found at the selected trust levels.", errorMessage);
+            }
+        };
+
+        FilterCredibilityInteractor interactor = new FilterCredibilityInteractor(presenter);
+        FilterCredibilityInputData inputData = new FilterCredibilityInputData(articles, filterLevels);
+        interactor.execute(inputData);
+    }
+
+    @Test
+    void error_emptyArticlesList() {
+        List<Article> articles = new ArrayList<>(); // Empty list
+
+        Set<String> filterLevels = new HashSet<>();
+        filterLevels.add("High");
+
+        FilterCredibilityOutputBoundary presenter = new FilterCredibilityOutputBoundary() {
+            @Override
+            public void presentSuccess(FilterCredibilityOutputData output) {
+                fail("Should not present success when articles list is empty.");
+            }
+
+            @Override
+            public void presentError(String errorMessage) {
+                assertEquals("Generate all scores to filter.", errorMessage);
+            }
+        };
+
+        FilterCredibilityInteractor interactor = new FilterCredibilityInteractor(presenter);
+        FilterCredibilityInputData inputData = new FilterCredibilityInputData(articles, filterLevels);
+        interactor.execute(inputData);
+    }
+
+    @Test
+    void success_caseInsensitiveFiltering() {
+
+        List<Article> articles = new ArrayList<>();
+        articles.add(createArticleWithScore("1", "High Trust Article", "High"));
+        articles.add(createArticleWithScore("2", "Medium Trust Article", "Medium"));
+        articles.add(createArticleWithScore("3", "Low Trust Article", "Low"));
+
+        Set<String> filterLevels = new HashSet<>();
+        filterLevels.add("high"); // lowercase
+
+        FilterCredibilityOutputBoundary presenter = new FilterCredibilityOutputBoundary() {
+            @Override
+            public void presentSuccess(FilterCredibilityOutputData output) {
+                assertEquals(1, output.getFilteredArticles().size());
+                assertEquals("High", output.getFilteredArticles().get(0).getConfidenceLevel());
+            }
+
+            @Override
+            public void presentError(String errorMessage) {
+                fail("Should not present error when filtering succeeds (case-insensitive).");
+            }
+        };
+
+        FilterCredibilityInteractor interactor = new FilterCredibilityInteractor(presenter);
+        FilterCredibilityInputData inputData = new FilterCredibilityInputData(articles, filterLevels);
+        interactor.execute(inputData);
+    }
+
+    @Test
+    void success_filterByAllLevels() {
+
+        List<Article> articles = new ArrayList<>();
+        articles.add(createArticleWithScore("1", "High Trust Article", "High"));
+        articles.add(createArticleWithScore("2", "Medium Trust Article", "Medium"));
+        articles.add(createArticleWithScore("3", "Low Trust Article", "Low"));
+
+        Set<String> filterLevels = new HashSet<>();
+        filterLevels.add("High");
+        filterLevels.add("Medium");
+        filterLevels.add("Low");
+
+        FilterCredibilityOutputBoundary presenter = new FilterCredibilityOutputBoundary() {
+            @Override
+            public void presentSuccess(FilterCredibilityOutputData output) {
+                assertEquals(3, output.getFilteredArticles().size());
+                assertEquals(filterLevels, output.getFilterLevels());
+            }
+
+            @Override
+            public void presentError(String errorMessage) {
+                fail("Should not present error when filtering by all levels.");
+            }
+        };
+
+        FilterCredibilityInteractor interactor = new FilterCredibilityInteractor(presenter);
+        FilterCredibilityInputData inputData = new FilterCredibilityInputData(articles, filterLevels);
+        interactor.execute(inputData);
+    }
 }

--- a/src/test/java/use_case/filter_credibility/FilterCredibilityInteractorTest.java
+++ b/src/test/java/use_case/filter_credibility/FilterCredibilityInteractorTest.java
@@ -16,8 +16,15 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class FilterCredibilityInteractorTest {
 
+    /**
+     * Helper method to create an article with a credibility score.
+     */
     private Article createArticleWithScore(String id, String title, String level) {
-        
+        // Create credibility score that results in the desired level
+        // High: overallTrust >= 0.8
+        // Medium: overallTrust >= 0.65
+        // Low: overallTrust < 0.65
+
         double sourceScore, sentimentScore, claimConfidence;
         
         if ("High".equals(level)) {


### PR DESCRIPTION
**Overview**

**Implements Use Case 7:** 
Filter Headlines by Trust Score. Users can filter articles by credibility level (High, Medium, Low) on the Top Headlines and Discover pages. Supports multiple selections and shows filtered results with existing colour coding.

**Main Flow**

- Filter articles by trust score level (High/Medium/Low)
- Multiple selection support (can select High + Medium, etc.)
- Filtered articles display with color coding:
- High: Green background
- Medium: Yellow background
- Low: Red background
- "Clear Filter" restores all articles

**Alternative Flows**

- Error handling: Shows "Generate all scores to filter." if articles are missing credibility scores
- Empty results: Shows "No articles found at the selected trust levels." if no articles match
- Articles remain visible when filter errors occur (error shown in popup)

**Edits to Use Case 14:**

- Updated so the discover feed is populated based on the logged in user's saved articles - not just overall saved articles
